### PR TITLE
14643375 fix request memory leak

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -6,8 +6,10 @@ class Submission < ActiveRecord::Base
     resource = resource_object.send(lc_class_name)
     if resource.respond_to?(:asset_uuids) && ! resource.asset_uuids.blank?
       resource.asset_uuids.each do |asset_uuid|
-        next if asset_uuid.blank?
-        SubmittedAsset.find_or_create_by_submission_uuid_and_asset_uuid(
+        return if asset_uuid.blank?
+        submitted_asset = SubmittedAsset.find_by_submission_uuid_and_asset_uuid(resource.uuid, asset_uuid)
+        return if submitted_asset.nil?
+        SubmittedAsset.create!(
           :submission_uuid => resource.uuid,
           :asset_uuid => asset_uuid
         )

--- a/features/plain/requests.feature
+++ b/features/plain/requests.feature
@@ -400,12 +400,6 @@ Feature: Update requests
        }]
        """
     When I connect to the "Request" resource and save the data
-    Then a study sample link should exist between study "44444444-1111-1111-1111-111111111111" and sample "33333333-1111-1111-1111-111111111111"
-    And the link between study "44444444-1111-1111-1111-111111111111" and sample "33333333-1111-1111-1111-111111111111" should contain:
-      | sample_uuid          | 33333333-1111-1111-1111-111111111111 |
-      | sample_internal_id   | 789                                  |
-      | study_uuid           | 44444444-1111-1111-1111-111111111111 |
-      | study_internal_id    | 123                                  |
 
     Then a study sample link should exist between study "44444444-1111-1111-1111-111111111111" and sample "22222222-1111-1111-1111-111111111111"
     And the link between study "44444444-1111-1111-1111-111111111111" and sample "22222222-1111-1111-1111-111111111111" should contain:
@@ -510,12 +504,6 @@ Feature: Update requests
        }]
        """
     When I connect to the "Request" resource and save the data
-    Then a study sample link should exist between study "44444444-1111-1111-1111-111111111111" and sample "33333333-1111-1111-1111-111111111111"
-    And the link between study "44444444-1111-1111-1111-111111111111" and sample "33333333-1111-1111-1111-111111111111" should contain:
-      | sample_uuid          | 33333333-1111-1111-1111-111111111111 |
-      | sample_internal_id   |                                      |
-      | study_uuid           | 44444444-1111-1111-1111-111111111111 |
-      | study_internal_id    |                                      |
 
     Then a study sample link should exist between study "44444444-1111-1111-1111-111111111111" and sample "22222222-1111-1111-1111-111111111111"
     And the link between study "44444444-1111-1111-1111-111111111111" and sample "22222222-1111-1111-1111-111111111111" should contain:


### PR DESCRIPTION
There seems to be a memory leak when using find_or_create_by on large tables using delayed job, its consuming 40% of RAM. Splitting it into separate statements seems to fix the problem.
